### PR TITLE
Fix the audio overhang guard: H3 rounds the grid to nearest, not up

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -35,6 +35,7 @@ import os
 import comfy.utils
 import folder_paths
 import node_helpers
+import torch
 
 try:
     from safetensors.torch import load_file as _st_load, save_file as _st_save
@@ -288,11 +289,13 @@ def _audio_tail_from_latent(latent, a_frames):
     generated H3 latent, skipping the decode -> re-encode round trip.
 
     Returns (tail latent [1, C, 2, rt], rt, overhang) where rt counts
-    40 Hz latent steps and overhang is the fraction of a step by which the
-    clip's audio grid extends past its last pixel frame. H3 rounds the
-    audio grid UP (124 frames want 206.67 steps, the layout allocates
-    207), so the latent's final step reaches ~overhang/40 s beyond the
-    last frame. The decoded-audio path never sees this because match_tail
+    40 Hz latent steps and overhang is the SIGNED fraction of a step
+    between the clip's audio grid and its last pixel frame. H3 rounds the
+    audio grid to the NEAREST step, not up: 124 frames want 206.67 and
+    become 207 (overhang +0.33), while 260 frames want 433.33 and become
+    433 (overhang -0.33). Any raw length with frames % 3 == 2 lands on the
+    negative side, so an unsigned band would fail open on half the legal
+    clip lengths. The decoded-audio path never sees this because match_tail
     cuts it; on this path the caller compensates the placement with it,
     so the pinned content lands exactly where its samples actually sit.
     """
@@ -312,7 +315,7 @@ def _audio_tail_from_latent(latent, a_frames):
     total_t = int(audio.shape[-1])
     frames = _pixel_frames(int(video.shape[2]))
     overhang = total_t - FRAME_RESCALE * frames
-    if not (0.0 <= overhang < 1.0):
+    if not (-0.5 < overhang < 0.5):
         _LOG.warning(
             "h3_motion_context: context_latent audio grid is unexpected "
             "(%d steps for %d frames); assuming no overhang.", total_t, frames)
@@ -577,9 +580,11 @@ class MiniMaxH3MotionContext:
                 # the tail of clip A, so both must end at the same instant
                 # of the new timeline -- frame `span` in head mode (where
                 # A's last frame sits), frame 0 in before mode. On the
-                # latent path the sliced content reaches `overhang` of a
-                # step past A's last frame (H3 rounds its audio grid up),
-                # so the end coordinate moves by exactly that much; the
+                # latent path the sliced content ends `overhang` of a step
+                # from A's last frame -- signed, because H3 rounds its audio
+                # grid to the nearest step, so the grid can end just short of
+                # the last frame as easily as past it. The end coordinate
+                # moves by exactly that much, in either direction; the
                 # layout patch takes a fractional frame index.
                 end_frame = float(span if anchor_mode == "head" else 0)
                 end_frame += overhang / FRAME_RESCALE
@@ -719,9 +724,14 @@ class MiniMaxH3MotionContextTrim:
                               "(%.2fms) so audio matches %d frames exactly",
                               over, over / sr * 1000.0, frames_left)
                 elif have < want:
-                    _LOG.warning("h3_motion_context: audio is %.2fms shorter than "
-                                 "%d frames; leaving the tail alone",
-                                 (want - have) / sr * 1000.0, frames_left)
+                    # A fractional-step shortage left alone compounds down a
+                    # chain: every clip's picture would run further ahead of
+                    # its sound than the last. Pad to the exact sample count.
+                    missing = want - have
+                    waveform = torch.nn.functional.pad(waveform, (0, missing))
+                    _LOG.info("h3_motion_context: tail padded %d zero samples "
+                              "(%.2fms) so audio matches %d frames exactly",
+                              missing, missing / sr * 1000.0, frames_left)
 
             out_audio = {"waveform": waveform, "sample_rate": sr}
             _LOG.info("h3_motion_context: %d frames / %.4fs picture, %.4fs sound, "


### PR DESCRIPTION
## The bug

`_audio_tail_from_latent` accepts `0.0 <= overhang < 1.0`, on the assumption that H3 allocates its audio grid upward from the pixel length. Core rounds to the **nearest** 40 Hz step instead.

So any raw length where `frames % 3 == 2` produces an overhang of `-1/3`, trips the guard, warns, and zeroes the compensation:

| frames | wanted steps | allocated | overhang | old guard |
| --- | --- | --- | --- | --- |
| 124 | 206.67 | 207 | +0.33 | accepted |
| 260 | 433.33 | 433 | -0.33 | **rejected** |
| 311 | 518.33 | 518 | -0.33 | **rejected** |

Roughly a third of legal clip lengths land on the negative side. On mine it fired on every clip of a three clip chain:

```
h3_motion_context: context_latent audio grid is unexpected (433 steps for 260 frames); assuming no overhang.
```

## It costs a whole audio step, not a third of one

This is the part that surprised me. The lost compensation is 8.3 ms, but the grid snap immediately after it amplifies the error.

Measured on a 260 frame context clip with a 22 frame window, driving `apply()` through the repo's own mock harness and comparing real behaviour against a simulated fail-open:

```
pre-fix : end_frame 22.2000   audio-coord 37.0000
fixed   : end_frame 21.6000   audio-coord 36.0000
delta   : -0.6 frames = -25.00 ms
```

Zeroing the `-1/3` overhang moves the end coordinate from 36.33 to 36.67, and `round()` then lands on **37 instead of 36**. The pinned window ends up on the wrong audio row entirely, a full step late, which is the direction and magnitude of the late offset I was hearing at joins.

## The change

1. **Signed band.** `-0.5 < overhang < 0.5` in `_audio_tail_from_latent`. Still fails open on a genuinely unexpected grid, now accepts both sides of nearest rounding. Docstring updated to state the rounding rule with both worked examples, and one inline comment in the `timeline` branch that repeated the old "rounds up" claim.
2. **Exact-count tail pad.** `MiniMaxH3MotionContextTrim`'s `match_tail` path zero-pads a short tail to the exact sample count rather than warning and leaving it, so a fractional step shortage cannot accumulate down a chain. This needs `torch`, which `nodes.py` did not previously import.

Both are ports from [ethanfel/ComfyUI-MiniMaxH3-Contex-Loop](https://github.com/ethanfel/ComfyUI-MiniMaxH3-Contex-Loop), which reached the same fix independently. Credit there, not here.

## Verification

`tests/_node_smoke_test.py` and `tests/_payload_gate_test.py` both pass unmodified on this branch. The smoke test still asserts `end_frame 22.2000` on the 124 frame case, so the positive overhang path is unchanged.

The negative case is not covered by the existing tests, since they only exercise 124 frames. I verified it out of band with the same harness. Happy to fold a 260 frame regression case into `_node_smoke_test.py` if you want it in this PR.

https://claude.ai/code/session_01MyKPmNRJ4KJ4zfxtUm1nh7
